### PR TITLE
deps: remove unused PrettyTable import

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -11,7 +11,6 @@ from io import StringIO
 
 # Import html formatting stuff
 from bs4 import BeautifulSoup
-from prettytable import PrettyTable
 import datetime
 
 # Import Additional common libs


### PR DESCRIPTION
The import is there, but I don't see that is getting used. I think that is better to remove it because that means a dependency less.

> [!NOTE]
> **For context:** 
> I was trying to use the custom nodes in a clean comfyUI installation and faced this problem:
> File "/comfyui/custom_nodes/anyPython/nodes/nodes.py", line 14, in
> from prettytable import PrettyTable
> ModuleNotFoundError: No module named 'prettytable'
> Cannot import /comfyui/custom_nodes/anyPython module for custom nodes: No module named 'prettytable'